### PR TITLE
Fix to allow updating pointer fields.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea
+*.iml
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/conform.go
+++ b/conform.go
@@ -161,7 +161,7 @@ func Strings(iface interface{}) error {
 	ift := reflect.Indirect(ifv).Type()
 	for i := 0; i < ift.NumField(); i++ {
 		v := ift.Field(i)
-		el := ifv.Elem().FieldByName(v.Name)
+		el := reflect.Indirect(ifv.Elem().FieldByName(v.Name))
 		switch el.Kind() {
 		case reflect.Struct:
 			Strings(el.Addr().Interface())


### PR DESCRIPTION
I often use pointer fields for strings so that they can be optional in json decoding.  This change allows conform to update these pointer fields.