### PR TITLE
close #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.glide/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - go get github.com/icrowley/fake
   - go get github.com/stretchr/testify
   - go get github.com/davecgh/go-spew/spew
-  - go get github.com/pmezard/go-difflib
+  - go get github.com/pmezard/go-difflib/difflib
   - mkdir -p ${GOPATH}/bin
   - cd ~
   - curl https://glide.sh/get | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - go get github.com/etgryphon/stringUp
   - go get github.com/icrowley/fake
   - go get github.com/stretchr/testify
-  - go get github.com/davecgh/go-spew
+  - go get github.com/davecgh/go-spew/spew
   - go get github.com/pmezard/go-difflib
   - mkdir -p ${GOPATH}/bin
   - cd ~

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ go:
 
 before_install:
   - sudo apt-get -qq update
+  - go get github.com/etgryphon/stringUp
+  - go get github.com/icrowley/fake
+  - go get github.com/stretchr/testify
+  - go get github.com/davecgh/go-spew
+  - go get github.com/pmezard/go-difflib
   - mkdir -p ${GOPATH}/bin
   - cd ~
   - curl https://glide.sh/get | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+
+language: go
+
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
+  - tip
+
+before_install:
+  - sudo apt-get -qq update
+  - mkdir -p ${GOPATH}/bin
+  - cd ~
+  - curl https://glide.sh/get | sh
+
+install:
+  - cd $GOPATH/src/github.com/${TRAVIS_REPO_SLUG}
+  - glide install
+
+script:
+  - go test

--- a/conform.go
+++ b/conform.go
@@ -164,19 +164,19 @@ func Strings(iface interface{}) error {
 		el := reflect.Indirect(ifv.Elem().FieldByName(v.Name))
 		switch el.Kind() {
 		case reflect.Slice:
-      if slice, ok := el.Interface().([]string); ok {
-        for i, input := range slice {
-  				tags := v.Tag.Get("conform")
-          slice[i] = transformString(input, tags)
-        }
-    		return nil
-      }
+			if slice, ok := el.Interface().([]string); ok {
+				for i, input := range slice {
+					tags := v.Tag.Get("conform")
+					slice[i] = transformString(input, tags)
+				}
+				return nil
+			}
 		case reflect.Struct:
 			Strings(el.Addr().Interface())
 		case reflect.String:
 			if el.CanSet() {
 				tags := v.Tag.Get("conform")
-        input := el.String()
+				input := el.String()
 				el.SetString(transformString(input, tags))
 			}
 		}
@@ -184,45 +184,45 @@ func Strings(iface interface{}) error {
 	return nil
 }
 
-func transformString (input, tags string) string {
-  if tags=="" {
-    return input
-  }
-  for _, split := range strings.Split(tags, ",") {
-    switch split {
-    case "trim":
-      input = strings.TrimSpace(input)
-    case "ltrim":
-      input = strings.TrimLeft(input, " ")
-    case "rtrim":
-      input = strings.TrimRight(input, " ")
-    case "lower":
-      input = strings.ToLower(input)
-    case "upper":
-      input = strings.ToUpper(input)
-    case "title":
-      input = strings.Title(input)
-    case "camel":
-      input = stringUp.CamelCase(input)
-    case "snake":
-      input = camelTo(stringUp.CamelCase(input), "_")
-    case "slug":
-      input = camelTo(stringUp.CamelCase(input), "-")
-    case "ucfirst":
-      input = ucFirst(input)
-    case "name":
-      input = formatName(input)
-    case "email":
-      input = strings.ToLower(strings.TrimSpace(input))
-    case "num":
-      input = onlyNumbers(input)
-    case "!num":
-      input = stripNumbers(input)
-    case "alpha":
-      input = onlyAlpha(input)
-    case "!alpha":
-      input = stripAlpha(input)
-    }
-  }
-  return input
+func transformString(input, tags string) string {
+	if tags == "" {
+		return input
+	}
+	for _, split := range strings.Split(tags, ",") {
+		switch split {
+		case "trim":
+			input = strings.TrimSpace(input)
+		case "ltrim":
+			input = strings.TrimLeft(input, " ")
+		case "rtrim":
+			input = strings.TrimRight(input, " ")
+		case "lower":
+			input = strings.ToLower(input)
+		case "upper":
+			input = strings.ToUpper(input)
+		case "title":
+			input = strings.Title(input)
+		case "camel":
+			input = stringUp.CamelCase(input)
+		case "snake":
+			input = camelTo(stringUp.CamelCase(input), "_")
+		case "slug":
+			input = camelTo(stringUp.CamelCase(input), "-")
+		case "ucfirst":
+			input = ucFirst(input)
+		case "name":
+			input = formatName(input)
+		case "email":
+			input = strings.ToLower(strings.TrimSpace(input))
+		case "num":
+			input = onlyNumbers(input)
+		case "!num":
+			input = stripNumbers(input)
+		case "alpha":
+			input = onlyAlpha(input)
+		case "!alpha":
+			input = stripAlpha(input)
+		}
+	}
+	return input
 }

--- a/conform.go
+++ b/conform.go
@@ -163,54 +163,66 @@ func Strings(iface interface{}) error {
 		v := ift.Field(i)
 		el := reflect.Indirect(ifv.Elem().FieldByName(v.Name))
 		switch el.Kind() {
+		case reflect.Slice:
+      if slice, ok := el.Interface().([]string); ok {
+        for i, input := range slice {
+  				tags := v.Tag.Get("conform")
+          slice[i] = transformString(input, tags)
+        }
+    		return nil
+      }
 		case reflect.Struct:
 			Strings(el.Addr().Interface())
 		case reflect.String:
 			if el.CanSet() {
-				t := v.Tag.Get("conform")
-				if t == "" {
-					continue
-				}
-				d := el.String()
-				for _, split := range strings.Split(t, ",") {
-					switch split {
-					case "trim":
-						d = strings.TrimSpace(d)
-					case "ltrim":
-						d = strings.TrimLeft(d, " ")
-					case "rtrim":
-						d = strings.TrimRight(d, " ")
-					case "lower":
-						d = strings.ToLower(d)
-					case "upper":
-						d = strings.ToUpper(d)
-					case "title":
-						d = strings.Title(d)
-					case "camel":
-						d = stringUp.CamelCase(d)
-					case "snake":
-						d = camelTo(stringUp.CamelCase(d), "_")
-					case "slug":
-						d = camelTo(stringUp.CamelCase(d), "-")
-					case "ucfirst":
-						d = ucFirst(d)
-					case "name":
-						d = formatName(d)
-					case "email":
-						d = strings.ToLower(strings.TrimSpace(d))
-					case "num":
-						d = onlyNumbers(d)
-					case "!num":
-						d = stripNumbers(d)
-					case "alpha":
-						d = onlyAlpha(d)
-					case "!alpha":
-						d = stripAlpha(d)
-					}
-				}
-				el.SetString(d)
+				tags := v.Tag.Get("conform")
+        input := el.String()
+				el.SetString(transformString(input, tags))
 			}
 		}
 	}
 	return nil
+}
+
+func transformString (input, tags string) string {
+  if tags=="" {
+    return input
+  }
+  for _, split := range strings.Split(tags, ",") {
+    switch split {
+    case "trim":
+      input = strings.TrimSpace(input)
+    case "ltrim":
+      input = strings.TrimLeft(input, " ")
+    case "rtrim":
+      input = strings.TrimRight(input, " ")
+    case "lower":
+      input = strings.ToLower(input)
+    case "upper":
+      input = strings.ToUpper(input)
+    case "title":
+      input = strings.Title(input)
+    case "camel":
+      input = stringUp.CamelCase(input)
+    case "snake":
+      input = camelTo(stringUp.CamelCase(input), "_")
+    case "slug":
+      input = camelTo(stringUp.CamelCase(input), "-")
+    case "ucfirst":
+      input = ucFirst(input)
+    case "name":
+      input = formatName(input)
+    case "email":
+      input = strings.ToLower(strings.TrimSpace(input))
+    case "num":
+      input = onlyNumbers(input)
+    case "!num":
+      input = stripNumbers(input)
+    case "alpha":
+      input = onlyAlpha(input)
+    case "!alpha":
+      input = stripAlpha(input)
+    }
+  }
+  return input
 }

--- a/conform_test.go
+++ b/conform_test.go
@@ -13,29 +13,29 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type testEmbeddedStruct struct {
+type TestEmbeddedStruct struct {
 	FirstName string `conform:"name"`
 }
 
-type testTwiceEmbeddedStruct struct {
-	testEmbeddedStruct
+type TestTwiceEmbeddedStruct struct {
+	TestEmbeddedStruct
 	LastName string `conform:"name"`
 }
 
-func (t *testTwiceEmbeddedStruct) private1() {}
-func (t *testTwiceEmbeddedStruct) private2() {}
-func (t *testTwiceEmbeddedStruct) Public1()  {}
-func (t *testTwiceEmbeddedStruct) Public2()  {}
+func (t *TestTwiceEmbeddedStruct) private1() {}
+func (t *TestTwiceEmbeddedStruct) private2() {}
+func (t *TestTwiceEmbeddedStruct) Public1()  {}
+func (t *TestTwiceEmbeddedStruct) Public2()  {}
 
-type testThriceEmbeddedStruct struct {
-	testTwiceEmbeddedStruct
+type TestThriceEmbeddedStruct struct {
+	TestTwiceEmbeddedStruct
 	Email string `conform:"email"`
 }
 
-func (t *testThriceEmbeddedStruct) private1() {}
-func (t *testThriceEmbeddedStruct) private2() {}
-func (t *testThriceEmbeddedStruct) Public1()  {}
-func (t *testThriceEmbeddedStruct) Public2()  {}
+func (t *TestThriceEmbeddedStruct) private1() {}
+func (t *TestThriceEmbeddedStruct) private2() {}
+func (t *TestThriceEmbeddedStruct) Public1()  {}
+func (t *TestThriceEmbeddedStruct) Public2()  {}
 
 type testSuite struct {
 	suite.Suite
@@ -485,11 +485,11 @@ F:
 
 }
 
-func (t *testSuite) TestEmbeddedStruct() {
+func (t *testSuite) TestEmbeddedStructfn() {
 	assert := assert.New(t.T())
 
 	var s struct {
-		testEmbeddedStruct
+		TestEmbeddedStruct
 		LastName string `conform:"name"`
 	}
 
@@ -504,11 +504,11 @@ func (t *testSuite) TestEmbeddedStruct() {
 	assert.Equal(ln, s.LastName, "Last name should be stripped of numbers")
 }
 
-func (t *testSuite) TestTwiceEmbeddedStruct() {
+func (t *testSuite) TestTwiceEmbeddedStructFn() {
 	assert := assert.New(t.T())
 
 	var s struct {
-		testTwiceEmbeddedStruct
+		TestTwiceEmbeddedStruct
 		Country string `conform:"trim,upper"`
 	}
 
@@ -526,11 +526,11 @@ func (t *testSuite) TestTwiceEmbeddedStruct() {
 	assert.Equal(s.Country, "UNITED KINGDOM", "Last name should be stripped of numbers")
 }
 
-func (t *testSuite) TestThriceEmbeddedStruct() {
+func (t *testSuite) TestThriceEmbeddedStructFn() {
 	assert := assert.New(t.T())
 
 	var s struct {
-		testThriceEmbeddedStruct
+		TestThriceEmbeddedStruct
 		Country string `conform:"trim,upper"`
 	}
 

--- a/conform_test.go
+++ b/conform_test.go
@@ -558,8 +558,8 @@ func (t *testSuite) TestSlice() {
 		Tags []string `conform:"trim"`
 	}
 
-  s.Tags = append(s.Tags, " some")
-  s.Tags = append(s.Tags, "string ")
+	s.Tags = append(s.Tags, " some")
+	s.Tags = append(s.Tags, "string ")
 
 	Strings(&s)
 
@@ -568,15 +568,15 @@ func (t *testSuite) TestSlice() {
 }
 
 func (t *testSuite) TestSliceOfSlice() {
-  return /* @todo skip for now. */
+	return /* @todo skip for now. */
 	assert := assert.New(t.T())
 
 	var s struct {
 		Tags [][]string `conform:"trim"`
 	}
 
-  s.Tags = append(s.Tags, []string{" some ", "other "})
-  s.Tags = append(s.Tags, []string{" string ", " beep "})
+	s.Tags = append(s.Tags, []string{" some ", "other "})
+	s.Tags = append(s.Tags, []string{" string ", " beep "})
 
 	Strings(&s)
 

--- a/conform_test.go
+++ b/conform_test.go
@@ -551,6 +551,39 @@ func (t *testSuite) TestThriceEmbeddedStructFn() {
 	assert.Equal(s.Country, "UNITED KINGDOM", "Last name should be stripped of numbers")
 }
 
+func (t *testSuite) TestSlice() {
+	assert := assert.New(t.T())
+
+	var s struct {
+		Tags []string `conform:"trim"`
+	}
+
+  s.Tags = append(s.Tags, " some")
+  s.Tags = append(s.Tags, "string ")
+
+	Strings(&s)
+
+	assert.Equal("some", s.Tags[0], "tags[0] should be trimmed")
+	assert.Equal("string", s.Tags[1], "tags[1] should be trimmed")
+}
+
+func (t *testSuite) TestSliceOfSlice() {
+  return /* @todo skip for now. */
+	assert := assert.New(t.T())
+
+	var s struct {
+		Tags [][]string `conform:"trim"`
+	}
+
+  s.Tags = append(s.Tags, []string{" some ", "other "})
+  s.Tags = append(s.Tags, []string{" string ", " beep "})
+
+	Strings(&s)
+
+	assert.Equal("some", s.Tags[0], "tags[0] should be trimmed")
+	assert.Equal("string", s.Tags[1], "tags[1] should be trimmed")
+}
+
 func TestStrings(t *testing.T) {
 	suite.Run(t, new(testSuite))
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,22 @@
+hash: 607db1abe03d9acc5078f52b23a82a220e00e3930433c59a74a58a76037e132f
+updated: 2016-08-24T23:11:38.341525533+02:00
+imports:
+- name: github.com/etgryphon/stringUp
+  version: 31534ccd8cac1d3d205c906ea5722928b045ed8c
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 2df174808ee097f90d259e432cc04442cf60be21
+  subpackages:
+  - spew
+- name: github.com/icrowley/fake
+  version: 84bff6d01560fb0b5a396ba29534e93fd00d09c6
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  subpackages:
+  - assert
+  - suite
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,10 @@
+package: github.com/mh-cbon/conform
+import:
+- package: github.com/etgryphon/stringUp
+testImport:
+- package: github.com/icrowley/fake
+- package: github.com/stretchr/testify
+  version: ^1.1.3
+  subpackages:
+  - assert
+  - suite


### PR DESCRIPTION
hey,

- added support for glide as PM
- added support for travis, testing from 1.4 to tip
- added support for slice of string, though only one level deep, i left a test to demonstrate that it does not work yet with slice of slice.

Mostly, i got to change the test structs definition, they were using un-exported types (lowercase first letter), which reflect could not handle.

I added a new test for string slices.

If there were support for slice of slice, i suspect there should be a more consequent refactoring of Strings method, about what i was lazy to do now.

If you merge it, please git tag the repo `git tag 1.0.0`, or whatever preferred version you d like to.

Test results are here https://travis-ci.org/mh-cbon/conform

I m curious to know if tests were passing on 1.4/1.5 given those unexported types, unfortunately i have not appropriately tested it via the CI.