### PR TITLE
Fix to prevent panic for unexpported fields

### DIFF
--- a/conform.go
+++ b/conform.go
@@ -164,7 +164,12 @@ func Strings(iface interface{}) error {
 		el := reflect.Indirect(ifv.Elem().FieldByName(v.Name))
 		switch el.Kind() {
 		case reflect.Struct:
-			Strings(el.Addr().Interface())
+			// need to check for unexported fields to prevent panic.
+			// for example, if there is a time.Time field, this loops through
+			// the struct, but all the fields in the struct are private
+			if v.PkgPath == "" {
+				Strings(el.Addr().Interface())
+			}
 		case reflect.String:
 			if el.CanSet() {
 				t := v.Tag.Get("conform")


### PR DESCRIPTION
Fixes situation when looping through structs that have private fields.  For example, fields that have a time.Time.