### PR TITLE
Make the email sanitization compliant with rfc

### DIFF
--- a/conform.go
+++ b/conform.go
@@ -24,6 +24,28 @@ var patterns = map[string]*regexp.Regexp{
 	"name":       regexp.MustCompile("[\\p{L}]([\\p{L}|[:space:]|-]*[\\p{L}])*"),
 }
 
+// a valid email will only have one "@", but let's treat the last "@" as the domain part separator
+func emailLocalPart(s string) string {
+	i := strings.LastIndex(s, "@")
+	if i == -1 {
+		return s
+	}
+	return s[0:i]
+}
+
+func emailDomainPart(s string) string {
+	i := strings.LastIndex(s, "@")
+	if i == -1 {
+		return ""
+	}
+	return s[i+1:]
+}
+
+func email(s string) string {
+	// According to rfc5321, "The local-part of a mailbox MUST BE treated as case sensitive"
+	return emailLocalPart(s) + "@" + strings.ToLower(emailDomainPart(s))
+}
+
 func camelTo(s, sep string) string {
 	var result string
 	var words []string
@@ -222,7 +244,7 @@ func transformString(input, tags string) string {
 		case "name":
 			input = formatName(input)
 		case "email":
-			input = strings.ToLower(strings.TrimSpace(input))
+			input = email(input)
 		case "num":
 			input = onlyNumbers(input)
 		case "!num":

--- a/conform.go
+++ b/conform.go
@@ -244,7 +244,7 @@ func transformString(input, tags string) string {
 		case "name":
 			input = formatName(input)
 		case "email":
-			input = email(input)
+			input = email(strings.TrimSpace(input))
 		case "num":
 			input = onlyNumbers(input)
 		case "!num":

--- a/conform_test.go
+++ b/conform_test.go
@@ -548,7 +548,8 @@ func (t *testSuite) TestThriceEmbeddedStructFn() {
 
 	assert.Equal(fn, s.FirstName, "First name should be stripped of numbers")
 	assert.Equal(ln, s.LastName, "Last name should be stripped of numbers")
-	assert.Equal(strings.ToLower(email), s.Email, "E-mail address should be lowercase")
+	assert.Equal(emailLocalPart(email), emailLocalPart(s.Email), "E-mail local part should not change")
+	assert.Equal(strings.ToLower(emailDomainPart(email)), emailDomainPart(s.Email), "E-mail domain part should be lowercase")
 	assert.Equal(s.Country, "UNITED KINGDOM", "Last name should be stripped of numbers")
 }
 


### PR DESCRIPTION
The local part must preserve case, the domain part is lowercased.
When supplied with a string containing multiple `@`s, treat the last `@` as the local part/domain part separator.