### PR TITLE
Fixing a bug where conform panics if a field isn't a struct

### DIFF
--- a/conform.go
+++ b/conform.go
@@ -173,10 +173,10 @@ func onlyOne(s string, m []x) string {
 func formatName(s string) string {
 	first := onlyOne(strings.ToLower(s), []x{
 		{"[^\\pL-\\s']": ""}, // cut off everything except [ alpha, hyphen, whitespace, apostrophe]
-		{"\\s{2,}": " "}, // trim more than two whitespaces to one
-		{"-{2,}": "-"}, // trim more than two hyphens to one
-		{"'{2,}": "'"}, // trim more than two apostrophes to one
-		{"( )*-( )*": "-"}, // trim enclosing whitespaces around hyphen
+		{"\\s{2,}": " "},     // trim more than two whitespaces to one
+		{"-{2,}": "-"},       // trim more than two hyphens to one
+		{"'{2,}": "'"},       // trim more than two apostrophes to one
+		{"( )*-( )*": "-"},   // trim enclosing whitespaces around hyphen
 	})
 	return strings.Title(patterns["name"].FindString(first))
 }
@@ -188,6 +188,9 @@ func Strings(iface interface{}) error {
 		return errors.New("Not a pointer")
 	}
 	ift := reflect.Indirect(ifv).Type()
+	if ift.Kind() != reflect.Struct {
+		return nil
+	}
 	for i := 0; i < ift.NumField(); i++ {
 		v := ift.Field(i)
 		el := reflect.Indirect(ifv.Elem().FieldByName(v.Name))


### PR DESCRIPTION
Conform was choking on a field in a struct which has a type of []byte.

The problem was in the recursive Strings method in which reflection is used to figure out the number of fields in a struct. In this edge case the []byte was passed in a recursive walk of the struct which resulted in a panic when calling ift.NumFields().

This is documented [here](https://golang.org/pkg/reflect/#Value.NumField):
> NumField returns the number of fields in the struct v. It panics if v's Kind is not Struct.

My solution is to return early in case the reflected variable is not a struct.

Thank you for your work!