### PR TITLE
Custom sanitizers

### DIFF
--- a/conform.go
+++ b/conform.go
@@ -16,6 +16,10 @@ import (
 
 type x map[string]string
 
+type sanitizer func(string) string
+
+var sanitizers = map[string]sanitizer{}
+
 var patterns = map[string]*regexp.Regexp{
 	"numbers":    regexp.MustCompile("[0-9]"),
 	"nonNumbers": regexp.MustCompile("[^0-9]"),
@@ -266,7 +270,16 @@ func transformString(input, tags string) string {
 			input = template.HTMLEscapeString(input)
 		case "!js":
 			input = template.JSEscapeString(input)
+		default:
+			if s, ok := sanitizers[split]; ok {
+				input = s(input)
+			}
 		}
 	}
 	return input
+}
+
+// AddSanitizer associates a sanitizer with a key, which can be used in a Struct tag
+func AddSanitizer(key string, s sanitizer) {
+	sanitizers[key] = s
 }

--- a/conform_test.go
+++ b/conform_test.go
@@ -453,9 +453,9 @@ func (t *testSuite) TestWeirdNames() {
 		"    %s%s%s-%s%s%s",   // leading spaces
 		"%s%s%s-%s%s%s     ",  // trailing spaces
 		"~%s£%s$%s-%s*%s(%s)", // single special characters
-		"%s'%s%s-%s%s''%s", // name with apostrophes
-		"%s     %s%s-%s%s%s", // multiple whitespaces
-		"%s%s%s  -  %s%s%s", // name with whitespace enclosed hyphen
+		"%s'%s%s-%s%s''%s",    // name with apostrophes
+		"%s     %s%s-%s%s%s",  // multiple whitespaces
+		"%s%s%s  -  %s%s%s",   // name with whitespace enclosed hyphen
 	}
 
 F:


### PR DESCRIPTION
I made the _minimum_ amount of changes needed to implement custom sanitizers.

Since no object is instantiated the code is not type-safe, i.e. two thread may try to add sanitizers at the same time resulting in a corrupt state.