### PR TITLE
[Proposal & PR] add `redact` tag for sensitive string scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,5 +212,9 @@ Removes non-alpha unicode characters. Example: `"!@£$%^&'()Hello 1234567890 Wor
 ---------------------------------------
 Removes alpha unicode characters. Example: `"Everything's here but the letters!"` -> `"'    !"`
 
+### redact
+---------------------------------------
+Replace with REDACTED. Example: `"Everything's here"` -> `"REDACTED"`
+
 ### LICENSE
 [MIT](https://github.com/leebenson/conform/blob/master/LICENSE)

--- a/conform.go
+++ b/conform.go
@@ -266,6 +266,8 @@ func transformString(input, tags string) string {
 			input = template.HTMLEscapeString(input)
 		case "!js":
 			input = template.JSEscapeString(input)
+		case "redact":
+			input = "REDACTED"
 		}
 	}
 	return input

--- a/conform_test.go
+++ b/conform_test.go
@@ -418,6 +418,19 @@ func (t *testSuite) TestStripNum() {
 	}
 }
 
+func (t *testSuite) TestRedact() {
+	assert := assert.New(t.T())
+
+	var s struct {
+		Secret string `conform:"redact"`
+	}
+
+	s.Secret = "secret"
+	expected := "REDACTED"
+	Strings(&s)
+	assert.Equal(expected, s.Secret, "Secret should be redacted")
+}
+
 func (t *testSuite) TestOnlyAlpha() {
 	assert := assert.New(t.T())
 
@@ -453,9 +466,9 @@ func (t *testSuite) TestWeirdNames() {
 		"    %s%s%s-%s%s%s",   // leading spaces
 		"%s%s%s-%s%s%s     ",  // trailing spaces
 		"~%s£%s$%s-%s*%s(%s)", // single special characters
-		"%s'%s%s-%s%s''%s", // name with apostrophes
-		"%s     %s%s-%s%s%s", // multiple whitespaces
-		"%s%s%s  -  %s%s%s", // name with whitespace enclosed hyphen
+		"%s'%s%s-%s%s''%s",    // name with apostrophes
+		"%s     %s%s-%s%s%s",  // multiple whitespaces
+		"%s%s%s  -  %s%s%s",   // name with whitespace enclosed hyphen
 	}
 
 F:

--- a/glide.lock
+++ b/glide.lock
@@ -1,22 +1,24 @@
-hash: 607db1abe03d9acc5078f52b23a82a220e00e3930433c59a74a58a76037e132f
-updated: 2016-08-24T23:11:38.341525533+02:00
+hash: ac4a8231e6e7a62314051d424722060aed80b1d8ed1f5187c46dcad47d1d15ad
+updated: 2018-05-30T13:31:53.816413-07:00
 imports:
 - name: github.com/etgryphon/stringUp
   version: 31534ccd8cac1d3d205c906ea5722928b045ed8c
 testImports:
+- name: github.com/corpix/uarand
+  version: 2b8494104d86337cdd41d0a49cbed8e4583c0ab4
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/icrowley/fake
-  version: 84bff6d01560fb0b5a396ba29534e93fd00d09c6
+  version: 4178557ae428460c3780a381c824a1f3aceb6325
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
-  - suite
   - require
+  - suite

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
 testImport:
 - package: github.com/icrowley/fake
 - package: github.com/stretchr/testify
-  version: ^1.1.3
+  version: ^1.2.1
   subpackages:
   - assert
   - suite


### PR DESCRIPTION
I was exploring the solution can help to redact sensitive data from a struct. I realize to use conform as a generic solution probably the best. This addition is simply to transform field to `REDACTED` if it has the tag. Check the example in _test.go file :)