### PR TITLE
Add support for sql.NullString

### DIFF
--- a/conform.go
+++ b/conform.go
@@ -228,7 +228,14 @@ func Strings(iface interface{}) error {
 			}
 		case reflect.Struct:
 			if el.CanAddr() && el.Addr().CanInterface() {
-				Strings(el.Addr().Interface())
+				// To handle "sql.NullString" we can assume that tags are added to field of type struct rather tan string
+				if tags := v.Tag.Get("conform"); tags != "" && el.CanSet() {
+					field := el.FieldByName("String")
+					str := field.String()
+					field.SetString(transformString(str, tags))
+				} else {
+					Strings(el.Addr().Interface())
+				}
 			}
 		case reflect.String:
 			if el.CanSet() {

--- a/conform.go
+++ b/conform.go
@@ -228,7 +228,7 @@ func Strings(iface interface{}) error {
 			}
 		case reflect.Struct:
 			if el.CanAddr() && el.Addr().CanInterface() {
-				// To handle "sql.NullString" we can assume that tags are added to field of type struct rather tan string
+				// To handle "sql.NullString" we can assume that tags are added to a field of type struct rather than string
 				if tags := v.Tag.Get("conform"); tags != "" && el.CanSet() {
 					field := el.FieldByName("String")
 					str := field.String()


### PR DESCRIPTION
Hi conform team

Thanks for the great job. I think the library lacks support for `sql.NullString`. There are many cases that we have structs with fields needed to be written to DB which use `NullString` as their data type. So I added some code to handle that situations too.
Therefore this structs are supported too:

```go
type Person struct {
    FirstName sql.NullString `conform:"name"` 
    LastName  sql.NullString `conform:"ucfirst,trim"` 
}
```
Let me know what you think. 
Thanks