### PR TITLE
Fixing issue with int slices

### DIFF
--- a/conform.go
+++ b/conform.go
@@ -240,7 +240,8 @@ func Strings(iface interface{}) error {
 
 				// allow strings and string pointers
 				str := ""
-				if elType.ConvertibleTo(reflect.TypeOf(str)) || elType.ConvertibleTo(reflect.TypeOf(&str)) {
+				if (elType.ConvertibleTo(reflect.TypeOf(str)) && reflect.TypeOf(str).ConvertibleTo(elType)) ||
+					(elType.ConvertibleTo(reflect.TypeOf(&str)) && reflect.TypeOf(&str).ConvertibleTo(elType) ) {
 					tags := v.Tag.Get("conform")
 					for i := 0; i < el.Len(); i++ {
 						el.Index(i).Set(transformValue(tags, el.Index(i)))

--- a/conform_test.go
+++ b/conform_test.go
@@ -758,3 +758,24 @@ func (t *testSuite) TestEmbeddedArrayOfStructs() {
 	Strings(&f)
 	assert.Equal("baz", (*f.Bars)[0].Baz)
 }
+
+func (t *testSuite) TestEmbeddedArrayOfStructsWithIntSlice() {
+	assert := assert.New(t.T())
+
+	type Bar struct {
+		Baz string `conform:"trim"`
+		Bak []int64
+	}
+	type Foo struct {
+		Bars *[]*Bar
+	}
+
+	f := Foo{
+		Bars: &[]*Bar{
+			{Baz: " baz ", Bak: []int64{1, 2, 3},},
+		},
+	}
+
+	Strings(&f)
+	assert.Equal("baz", (*f.Bars)[0].Baz)
+}


### PR DESCRIPTION
It seems reflect will allow a large list of types to be converted to strings but not string to those types.  This adds a check for the backwards compatibility to stop panics from occurring, for example, structs with slices of int64.