### PR TITLE
Fixes #38

### DIFF
--- a/conform.go
+++ b/conform.go
@@ -243,6 +243,9 @@ func Strings(iface interface{}) error {
 				if (elType.ConvertibleTo(reflect.TypeOf(str)) && reflect.TypeOf(str).ConvertibleTo(elType)) ||
 					(elType.ConvertibleTo(reflect.TypeOf(&str)) && reflect.TypeOf(&str).ConvertibleTo(elType) ) {
 					tags := v.Tag.Get("conform")
+					if len(tags) <= 0 {
+						continue
+					}
 					for i := 0; i < el.Len(); i++ {
 						el.Index(i).Set(transformValue(tags, el.Index(i)))
 					}


### PR DESCRIPTION
Add a length check when reading "conform" tags, if length == 0 (<=0) then just ignore the field. This minor change should be enough to fix the problem.
Also this is consistent with the original design concept 

```
Password  string    `schema:"password"`    // <-- no tag? no change
```
